### PR TITLE
Implement hiding commitments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0
+
+- Modify specification & implementation to use perfectly hiding commitments.
+
 # 0.4.0
 
 - Added key refresh and resharing protocols.

--- a/docs/key-generation.md
+++ b/docs/key-generation.md
@@ -28,7 +28,7 @@ if $S = \bot$.
 3. Each $P_i$ samples $f \xleftarrow{\\\$} \mathbb{F}_ q[X]_ {\leq t - 1}$,
 subject to the constraint that $f(0) = s_i$.
 4. Each $P_i$ sets $F_ i \gets f \cdot G$.
-5. Each $P_i$ sets $\text{Com}_i \gets H(F_i)$.
+5. Each $P_i$ sets $(\text{Com}_i, r_i) \gets \text{Commit}(F_i)$.
 6. $\star$ Each $P_i$ sends $\text{Com}_i$ to every other party.
 
 **Round 2:**
@@ -38,15 +38,15 @@ subject to the constraint that $f(0) = s_i$.
 3. $T.\text{Add}(\text{Confirm}_i)$
 4. $\star$ Each $P_i$ sends $\text{Confirm}_i$ to every other party.
 5. Each $P_i$ generates the proof $\pi_i \gets \text{Prove}(T.\text{Cloned}(\texttt{dlog0}, i), \text{Mau}(- \cdot G, F_{i}(0); f(0)))$.
-6. $\star$ Each $P_i$ sends $(F_i, \pi_i)$ to every other party.
+6. $\star$ Each $P_i$ sends $(F_i, r_i, \pi_i)$ to every other party.
 7. $\textcolor{red}{\star}$ Each $P_i$ *privately* sends $x_i^j := f(j)$ to each other party $P_j$, and saves $x_i^i$ for itself.
 
 **Round 3:**
 
 1. $\bullet$ Each $P_i$ waits to receive $\text{Confirm}_j$ from each other $P_j$.
 2. $\blacktriangle$ Each $P_i$ *asserts* that $\forall j \in [N].\ \text{Confirm}_j = \text{Confirm}_i$, aborting otherwise.
-3. $\bullet$ Each $P_i$ waits to receive $(F_j, \pi_j)$ from each other $P_j$.
-4. $\blacktriangle$ Each $P_i$ *asserts* that $\forall j \in [N].\ \text{deg}(F_ j) = t -1 \land H(F_j) = \text{Com}_j \land \text{Verify}(T.\text{Cloned}(\texttt{dlog0}, j), \pi_j, \text{Mau}({- \cdot G}, F_j(0)))$.
+3. $\bullet$ Each $P_i$ waits to receive $(F_j, r_j, \pi_j)$ from each other $P_j$.
+4. $\blacktriangle$ Each $P_i$ *asserts* that $\forall j \in [N].\ \text{deg}(F_ j) = t -1 \land \text{CheckCommit}(\text{Com}_j, F_j, r_j) \land \text{Verify}(T.\text{Cloned}(\texttt{dlog0}, j), \pi_j, \text{Mau}({- \cdot G}, F_j(0)))$.
 5. $\bullet$ Each $P_i$ waits to receive $x_j^i$ from each other $P_j$.
 6. Each $P_i$ sets $x_i \gets \sum_j x^i_j$ and $X \gets \sum_j F_j(0)$.
 7. $\blacktriangle$ Each $P_i$ asserts that $x_i \cdot G = (\sum_j F_j)(i)$.

--- a/docs/triples.md
+++ b/docs/triples.md
@@ -152,7 +152,7 @@ This protocol is also parameterized by a unique session id $\text{sid}$
 using $X_{ij}$ as its input.
 The parties receive $T_ {ij}$ and $Q_ {ij}$ respectively.
 3. $\mathcal{S}$ samples $s \xleftarrow{R} \mathbb{F}_2^\lambda$.
-4. $\star$ $\mathcal{S}$ sends $s$ to $\mathcal{R}
+4. $\star$ $\mathcal{S}$ sends $s$ to $\mathcal{R}$.
 5. $\bullet$ $\mathcal{R}$ waits to receive $s$.
 6. Let $\mu \gets \lceil \kappa' / \lambda \rceil$,
 then, the parties set $\hat{T}_ {ij}$, $\hat{b}_ i$, $\hat{Q}_ {ij}$,
@@ -285,7 +285,7 @@ which want to generate a triple with threshold $t$.
 1. $T.\text{Add}(\mathcal{P}, t)$
 2. Each $P_ i$ samples $e, f \xleftarrow{R} \mathbb{F}_ q[X]_ {\leq (t - 1)}$.
 3. Each $P_i$ sets $E_i \gets e \cdot G$, and $F_i \gets f \cdot G$.
-4. Each $P_i$ sets $\text{Com}_i \gets H(E_i, F_I)$.
+4. Each $P_i$ sets $(\text{Com}_i, r_i) \gets \text{Commit}((E_i, F_i))$.
 5. $\star$ Each $P_i$ sends $\text{Com}_i$ to all other parties.
 
 **Round 2:**
@@ -304,20 +304,20 @@ $$
 \end{aligned}
 $$
 
-7. $\star$ Each $P_i$ sends $(E_i, F_i, \pi_i)$ to every other party.
+7. $\star$ Each $P_i$ sends $(E_i, F_i, r_i, \pi_i)$ to every other party.
 7. $\textcolor{red}{\star}$ Each $P_i$ *privately* sends $a_i^j = e(j)$ and $b_i^j$ = $f(j)$ to every other party $P_j$.
 
 **Round 3:**
 
 1. $\bullet$ Each $P_i$ waits to receive $\text{Confirm}_j$ from each other $P_j$.
 2. $\blacktriangle$ Each $P_i$ *asserts* that $\forall P_j.\ \text{Confirm}_j = \text{Confirm}_i$.
-3. $\bullet$ Each $P_i$ waits to receive $(E_j, F_j, \pi_j)$ from each other $P_j$.
+3. $\bullet$ Each $P_i$ waits to receive $(E_j, F_j, r_i, \pi_j)$ from each other $P_j$.
 4. $\blacktriangle$ Each $P_i$ asserts that $\forall P_j$:
 
 $$
 \begin{aligned}
 &\text{deg}(E_j) = \text{deg}(F_j) = t - 1\cr
-&H(E_j, F_j) = \text{Com}_j\cr
+&\text{CheckCommit}(\text{Com}_j, (E_j, F_j), r_j)\cr
 &\text{Verify}(T.\text{Cloned}(\texttt{dlog0}, j), \pi_j, \text{Mau}(- \cdot G, F_j(0)))\cr
 \end{aligned}
 $$

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,14 +1,25 @@
 use std::io::Write;
 
 use ck_meow::Meow;
+use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
 use crate::serde::encode_writer;
 
 const COMMIT_LABEL: &[u8] = b"cait-sith v0.1.0 commitment";
 const COMMIT_LEN: usize = 32;
+const RANDOMIZER_LEN: usize = 32;
+const HASH_LABEL: &[u8] = b"cait-sith v0.1.0 generic hash";
+const HASH_LEN: usize = 32;
 
 struct MeowWriter<'a>(&'a mut Meow);
+
+impl<'a> MeowWriter<'a> {
+    fn init(meow: &'a mut Meow) -> Self {
+        meow.ad(&[], false);
+        Self(meow)
+    }
+}
 
 impl<'a> Write for MeowWriter<'a> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
@@ -21,25 +32,85 @@ impl<'a> Write for MeowWriter<'a> {
     }
 }
 
-/// Represents a commitment to some value.
+/// Represents the randomizer used to make a commit hiding.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Commitment([u8; COMMIT_LEN]);
+pub struct Randomizer([u8; RANDOMIZER_LEN]);
 
-impl AsRef<[u8]> for Commitment {
+impl Randomizer {
+    /// Generate a new randomizer value by sampling from an RNG.
+    fn random<R: CryptoRngCore>(rng: &mut R) -> Self {
+        let mut out = [0u8; RANDOMIZER_LEN];
+        rng.fill_bytes(&mut out);
+        Self(out)
+    }
+}
+
+impl AsRef<[u8]> for Randomizer {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
+/// Represents a commitment to some value.
+///
+/// This commit is both binding, in that it can't be opened to a different
+/// value than the one committed, and hiding, in that it hides the value
+/// committed inside (perfectly).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Commitment([u8; COMMIT_LEN]);
+
+impl Commitment {
+    fn compute<T: Serialize>(val: &T, r: &Randomizer) -> Self {
+        let mut meow = Meow::new(COMMIT_LABEL);
+
+        meow.ad(r.as_ref(), false);
+        meow.meta_ad(b"start data", false);
+        encode_writer(&mut MeowWriter::init(&mut meow), val);
+
+        let mut out = [0u8; COMMIT_LEN];
+        meow.prf(&mut out, false);
+
+        Commitment(out)
+    }
+
+    /// Check that a value and a randomizer match this commitment.
+    #[must_use]
+    pub fn check<T: Serialize>(&self, val: &T, r: &Randomizer) -> bool {
+        let actual = Self::compute(val, r);
+        *self == actual
+    }
+}
+
 /// Commit to an arbitrary serializable value.
-pub fn commit<T: Serialize>(val: &T) -> Commitment {
-    let mut meow = Meow::new(COMMIT_LABEL);
+///
+/// This also returns a fresh randomizer, which is used to make sure that the
+/// commitment perfectly hides the value contained inside.
+///
+/// This value will need to be sent when opening the commitment to allow
+/// others to check that the opening is valid.
+pub fn commit<T: Serialize, R: CryptoRngCore>(rng: &mut R, val: &T) -> (Commitment, Randomizer) {
+    let r = Randomizer::random(rng);
+    let c = Commitment::compute(val, &r);
+    (c, r)
+}
 
-    meow.ad(&[], false);
-    encode_writer(&mut MeowWriter(&mut meow), val);
+/// The output of a generic hash function.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Digest([u8; HASH_LEN]);
 
-    let mut out = [0u8; COMMIT_LEN];
+impl AsRef<[u8]> for Digest {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Hash some value to produce a short digest.
+pub fn hash<T: Serialize>(val: &T) -> Digest {
+    let mut meow = Meow::new(HASH_LABEL);
+    encode_writer(&mut MeowWriter::init(&mut meow), val);
+
+    let mut out = [0u8; HASH_LEN];
     meow.prf(&mut out, false);
 
-    Commitment(out)
+    Digest(out)
 }

--- a/src/presign.rs
+++ b/src/presign.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// The output of the presigning protocol.
-/// 
+///
 /// This output is basically all the parts of the signature that we can perform
 /// without knowing the message.
 #[derive(Debug, Clone)]
@@ -202,10 +202,10 @@ async fn do_presign(
 }
 
 /// The presignature protocol.
-/// 
+///
 /// This is the first phase of performing a signature, in which we perform
 /// all the work we can do without yet knowing the message to be signed.
-/// 
+///
 /// This work does depend on the private key though, and it's crucial
 /// that a presignature is never used.
 pub fn presign(

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,5 +1,5 @@
 //! This module provides abstractions for working with protocols.
-//! 
+//!
 //! This library tries to abstract away as much of the internal machinery
 //! of protocols as much as possible. To use a protocol, you just need to be able
 //! to deliver messages to and from that protocol, and eventually it will produce
@@ -145,7 +145,7 @@ pub trait Protocol {
 /// Run a protocol to completion, synchronously.
 ///
 /// This works by executing each participant in order.
-/// 
+///
 /// The reason this function exists is as a convenient testing utility.
 /// In practice each protocol participant is likely running on a different machine,
 /// and so orchestrating the protocol would happen differently.

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -51,7 +51,6 @@ async fn do_sign(
     // Spec 1.3
     let m = compat::scalar_hash(&msg);
 
-
     let r = compat::x_coordinate(&presignature.big_r);
     let s_i = m * k_i + r * sigma_i;
 
@@ -89,7 +88,7 @@ async fn do_sign(
 }
 
 /// The signature protocol, allowing us to use a presignature to sign a message.
-/// 
+///
 /// We intentionally take in the full message before hashing, rather than a hash,
 /// because it prevents potential API misuse. In particular, it's expected
 /// that each node participating in threshold signing verifies that they

--- a/src/triples/bits.rs
+++ b/src/triples/bits.rs
@@ -344,7 +344,9 @@ impl ChoiceVector {
     pub fn random(rng: &mut impl CryptoRngCore, size: usize) -> Self {
         assert!(size > 0 && size % SECURITY_PARAMETER == 0);
 
-        let data = (0..(size / SECURITY_PARAMETER)).map(|_| BitVector::random(rng)).collect();
+        let data = (0..(size / SECURITY_PARAMETER))
+            .map(|_| BitVector::random(rng))
+            .collect();
 
         Self(data)
     }

--- a/src/triples/correlated_ot_extension.rs
+++ b/src/triples/correlated_ot_extension.rs
@@ -83,8 +83,7 @@ fn run_correlated_ot(
             correlated_ot_sender(ctx_s.private_channel(s, r), params, delta, k),
         ),
         &mut make_protocol(ctx_r.clone(), async move {
-            let out =
-                correlated_ot_receiver(ctx_r.private_channel(r, s), params, k0, k1, x).await;
+            let out = correlated_ot_receiver(ctx_r.private_channel(r, s), params, k0, k1, x).await;
             Ok(out)
         }),
     )

--- a/src/triples/mod.rs
+++ b/src/triples/mod.rs
@@ -1,27 +1,27 @@
 //! This module contains the types and protocols related to triple generation.
-//! 
+//!
 //! The cait-sith signing protocol makes use of *committed* Beaver Triples.
 //! A triple is a value of the form `(a, b, c), (A, B, C)`, such that
 //! `c = a * b`, and `A = a * G`, `B = b * G`, `C = c * G`. This is a beaver
 //! triple along with commitments to its values in the form of group elements.
-//! 
+//!
 //! The signing protocols make use of a triple where the scalar values `(a, b, c)`
 //! are secret-shared, and the commitments are public. Each signature requires
 //! two triples. These triples can be generated in advance without knowledge
 //! of the secret key used to sign. It's important that the value of the underlying
 //! scalars in the triple is kept secret, otherwise the private key used to create
 //! a signature with that triple could be recovered.
-//! 
+//!
 //! There are two ways of generating these triples.
-//! 
+//!
 //! One way is to have
 //! a trusted third party generate them. This is supported by the [deal] function.
-//! 
+//!
 //! The other way is to run a protocol generating a secret shared triple without any party
 //! learning the secret values. This is better because no party learns the value of the
 //! triple, which needs to be kept secret. This method is supported by the [generate_triple]
 //! protocol.
-//! 
+//!
 //! This protocol requires a setup protocol to be one once beforehand.
 //! After this setup protocol has been run, an arbitarary number of triples can
 //! be generated.
@@ -103,11 +103,11 @@ pub fn deal(
 mod batch_random_ot;
 mod bits;
 mod correlated_ot_extension;
-mod random_ot_extension;
 mod generation;
-mod multiplication;
 mod mta;
+mod multiplication;
+mod random_ot_extension;
 mod triple_setup;
 
-pub use triple_setup::{Setup, SingleSetup, setup};
 pub use generation::{generate_triple, TripleGenerationOutput};
+pub use triple_setup::{setup, Setup, SingleSetup};

--- a/src/triples/multiplication.rs
+++ b/src/triples/multiplication.rs
@@ -3,7 +3,7 @@ use k256::{Scalar, Secp256k1};
 
 use crate::{
     constants::SECURITY_PARAMETER,
-    crypto::Commitment,
+    crypto::Digest,
     protocol::{
         internal::{Context, PrivateChannel},
         Participant, ProtocolError,
@@ -89,7 +89,7 @@ pub async fn multiplication_receiver<'a>(
 
 pub async fn multiplication(
     ctx: Context<'_>,
-    sid: Commitment,
+    sid: Digest,
     me: Participant,
     setup: Setup,
     a_i: Scalar,
@@ -126,7 +126,7 @@ mod test {
     use rand_core::OsRng;
 
     use crate::{
-        crypto::commit,
+        crypto::hash,
         protocol::{
             internal::{make_protocol, Context},
             run_protocol, Participant, Protocol, ProtocolError,
@@ -174,7 +174,7 @@ mod test {
         let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = Scalar>>)> =
             Vec::with_capacity(prep.len());
 
-        let sid = commit(b"sid");
+        let sid = hash(b"sid");
 
         for (p, setup, a_i, b_i) in prep {
             let ctx = Context::new();

--- a/src/triples/triple_setup.rs
+++ b/src/triples/triple_setup.rs
@@ -4,7 +4,7 @@ use crate::{
     participants::ParticipantList,
     protocol::{
         internal::{make_protocol, Context, PrivateChannel},
-        InitializationError, Participant, ProtocolError, Protocol,
+        InitializationError, Participant, Protocol, ProtocolError,
     },
 };
 
@@ -44,18 +44,12 @@ impl Setup {
     }
 }
 
-async fn do_sender(
-    ctx: Context<'_>,
-    chan: PrivateChannel,
-) -> Result<SingleSetup, ProtocolError> {
+async fn do_sender(ctx: Context<'_>, chan: PrivateChannel) -> Result<SingleSetup, ProtocolError> {
     let (delta, k) = batch_random_ot_receiver(ctx, chan).await?;
     Ok(SingleSetup::Sender(delta, k))
 }
 
-async fn do_receiver(
-    ctx: Context<'_>,
-    chan: PrivateChannel,
-) -> Result<SingleSetup, ProtocolError> {
+async fn do_receiver(ctx: Context<'_>, chan: PrivateChannel) -> Result<SingleSetup, ProtocolError> {
     let (k0, k1) = batch_random_ot_sender(ctx, chan).await?;
     Ok(SingleSetup::Receiver(k0, k1))
 }
@@ -89,7 +83,7 @@ async fn do_setup(
 }
 
 /// Runs a setup protocol among all participants, to prepare for triple generation later.
-/// 
+///
 /// This only needs to be one once, in order to generate an arbitrary number of triples.
 pub fn setup(
     participants: &[Participant],


### PR DESCRIPTION
This isn't a completely necessary change, but makes the specification more closely match the proof. Using hiding commitments makes the proof easier because you don't need to assume anything about the entropy of elements being committed, even though in practice these elements were all random polynomials, so high enough entropy.